### PR TITLE
[refactor] 기존 코드 리팩터링

### DIFF
--- a/src/main/java/com/java/Main.java
+++ b/src/main/java/com/java/Main.java
@@ -12,8 +12,8 @@ import com.java.service.calculator.calculate.CalculatorService;
 import com.java.service.calculator.calculate.CalculatorServiceImpl;
 import com.java.service.calculator.delimiter.DelimiterService;
 import com.java.service.calculator.delimiter.DelimiterServiceImpl2;
-import com.java.service.calculator.valueextractor.ValueExtractService;
-import com.java.service.calculator.valueextractor.ValueExtractServiceImpl;
+import com.java.service.calculator.operand.OperandService;
+import com.java.service.calculator.operand.OperandServiceImpl;
 import com.java.view.InputView;
 import com.java.view.OutputView;
 
@@ -27,9 +27,9 @@ public class Main {
         DelimiterService delimiterService = new DelimiterServiceImpl2(delimiterRepository);
         OperandRepository operandRepository = new OperandRepository();
         OutputValueRepository outputValueRepository = new OutputValueRepository();
-        ValueExtractService valueExtractService = new ValueExtractServiceImpl(delimiterRepository, operandRepository);
+        OperandService operandService = new OperandServiceImpl(operandRepository);
         CalculatorService calculatorService = new CalculatorServiceImpl(operandRepository, outputValueRepository);
-        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterService, valueExtractService, calculatorService);
+        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterService, operandService, calculatorService);
 
         OutputView outputView = new OutputView(outputValueRepository);
         InputView inputView = new InputView(inputValueHandler);

--- a/src/main/java/com/java/Main.java
+++ b/src/main/java/com/java/Main.java
@@ -3,6 +3,8 @@ package com.java;
 import com.java.controller.CalculatorController;
 import com.java.service.calculator.delimiter.DelimiterFacade;
 import com.java.service.calculator.delimiter.DelimiterFacadeImpl;
+import com.java.service.calculator.operand.OperandFacade;
+import com.java.service.calculator.operand.OperandFacadeImpl;
 import com.java.service.io.input.InputValueServiceImpl;
 import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.input.InputValueRepository;
@@ -36,7 +38,8 @@ public class Main {
         CalculatorService calculatorService = new CalculatorServiceImpl();
         OutputView outputView = new OutputView(outputValueService);
         DelimiterFacade delimiterFacade = new DelimiterFacadeImpl(delimiterService);
-        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterFacade,operandService,calculatorService,outputValueService,outputView);
+        OperandFacade operandFacade = new OperandFacadeImpl(operandService);
+        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterFacade, calculatorService, outputValueService, operandFacade);
         InputView inputView = new InputView(inputValueHandler);
         CalculatorController calculatorController = new CalculatorController(inputView,outputView,calculatorFacade);
         calculatorController.calculator();

--- a/src/main/java/com/java/Main.java
+++ b/src/main/java/com/java/Main.java
@@ -1,7 +1,9 @@
 package com.java;
 
 import com.java.controller.CalculatorController;
-import com.java.service.io.InputValueHandlerImpl;
+import com.java.service.calculator.delimiter.DelimiterFacade;
+import com.java.service.calculator.delimiter.DelimiterFacadeImpl;
+import com.java.service.io.input.InputValueServiceImpl;
 import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.input.InputValueRepository;
 import com.java.repository.operand.OperandRepository;
@@ -14,6 +16,8 @@ import com.java.service.calculator.delimiter.DelimiterService;
 import com.java.service.calculator.delimiter.DelimiterServiceImpl2;
 import com.java.service.calculator.operand.OperandService;
 import com.java.service.calculator.operand.OperandServiceImpl;
+import com.java.service.io.output.OutputValueService;
+import com.java.service.io.output.OutputValueServiceImpl;
 import com.java.view.InputView;
 import com.java.view.OutputView;
 
@@ -22,16 +26,17 @@ import java.io.IOException;
 public class Main {
     public static void main(String[] args) throws IOException {
         InputValueRepository inputValueRepository = new InputValueRepository();
-        InputValueHandlerImpl inputValueHandler = new InputValueHandlerImpl(inputValueRepository);
+        InputValueServiceImpl inputValueHandler = new InputValueServiceImpl(inputValueRepository);
         DelimiterRepository delimiterRepository = new DelimiterRepository();
         DelimiterService delimiterService = new DelimiterServiceImpl2(delimiterRepository);
         OperandRepository operandRepository = new OperandRepository();
         OutputValueRepository outputValueRepository = new OutputValueRepository();
         OperandService operandService = new OperandServiceImpl(operandRepository);
-        CalculatorService calculatorService = new CalculatorServiceImpl(operandRepository, outputValueRepository);
-        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterService, operandService, calculatorService);
-
-        OutputView outputView = new OutputView(outputValueRepository);
+        OutputValueService outputValueService = new OutputValueServiceImpl(outputValueRepository);
+        CalculatorService calculatorService = new CalculatorServiceImpl();
+        OutputView outputView = new OutputView(outputValueService);
+        DelimiterFacade delimiterFacade = new DelimiterFacadeImpl(delimiterService);
+        CalculatorFacade calculatorFacade = new CalculatorFacadeImpl(delimiterFacade,operandService,calculatorService,outputValueService,outputView);
         InputView inputView = new InputView(inputValueHandler);
         CalculatorController calculatorController = new CalculatorController(inputView,outputView,calculatorFacade);
         calculatorController.calculator();

--- a/src/main/java/com/java/controller/CalculatorController.java
+++ b/src/main/java/com/java/controller/CalculatorController.java
@@ -1,6 +1,7 @@
 package com.java.controller;
 
-import com.java.service.io.InputValueHandler;
+import com.java.repository.operand.Operand;
+import com.java.repository.output.OutputValue;
 import com.java.service.calculator.CalculatorFacade;
 import com.java.view.InputView;
 import com.java.view.OutputView;
@@ -19,10 +20,8 @@ public class CalculatorController {
     }
     public void calculator() throws IOException {
         String value=inputView.stringCalculatorView();
-        calculatorFacade.calculate(value);
-        outputView.stringCalculatorResultView();
-
-
+        OutputValue result = calculatorFacade.calculate(value);
+        outputView.stringCalculatorResultView(result);
 
     }
 }

--- a/src/main/java/com/java/exception/ErrorCode.java
+++ b/src/main/java/com/java/exception/ErrorCode.java
@@ -3,7 +3,8 @@ package com.java.exception;
 public enum ErrorCode {
     NO_ARG_INPUT("입력값이 아무것도 입력되지 않았습니다"),
     IS_ONLY_SPACE("스페이스만 입력이 되었습니다"),
-    CUSTOM_DELIMITER_IS_NOT_VALIDATED("커스텀 구분자는 문자여야 합니다.");
+    CUSTOM_DELIMITER_IS_NOT_VALIDATED("커스텀 구분자는 문자여야 합니다."),
+    INPUT_VALUE_ONLY_INTEGER("구분자를 제외한 모든 문자는 정수여야 합니다.");
 
     private final String message;
     ErrorCode(String message){

--- a/src/main/java/com/java/repository/output/OutputValue.java
+++ b/src/main/java/com/java/repository/output/OutputValue.java
@@ -10,4 +10,5 @@ public class OutputValue {
     public Integer getValue(){
         return this.outputValue;
     }
+
 }

--- a/src/main/java/com/java/service/calculator/CalculatorFacade.java
+++ b/src/main/java/com/java/service/calculator/CalculatorFacade.java
@@ -1,5 +1,7 @@
 package com.java.service.calculator;
 
+import com.java.repository.output.OutputValue;
+
 public interface CalculatorFacade {
-    public void calculate(String value);
+    public OutputValue calculate(String value);
 }

--- a/src/main/java/com/java/service/calculator/CalculatorFacadeImpl.java
+++ b/src/main/java/com/java/service/calculator/CalculatorFacadeImpl.java
@@ -1,27 +1,48 @@
 package com.java.service.calculator;
 
+import com.java.repository.delimiter.Delimiter;
+import com.java.repository.operand.Operand;
+import com.java.repository.output.OutputValue;
 import com.java.service.calculator.calculate.CalculatorService;
+import com.java.service.calculator.delimiter.DelimiterFacade;
+import com.java.service.calculator.delimiter.DelimiterFacadeImpl;
 import com.java.service.calculator.delimiter.DelimiterService;
 import com.java.service.calculator.validator.Validator;
-import com.java.service.calculator.valueextractor.ValueExtractService;
+import com.java.service.calculator.operand.OperandService;
+import com.java.service.io.output.OutputValueService;
+import com.java.view.OutputView;
+
+import java.util.List;
 
 public class CalculatorFacadeImpl implements CalculatorFacade {
-    private final DelimiterService delimiterService;
-    private final ValueExtractService valueExtractService;
+    private final OperandService operandService;
     private final CalculatorService calculatorService;
+    private final OutputValueService outputValueService;
+    private final OutputView outputView;
 
-    public CalculatorFacadeImpl(DelimiterService delimiterService, ValueExtractService valueExtractService, CalculatorService calculatorService) {
-        this.delimiterService = delimiterService;
-        this.valueExtractService = valueExtractService;
+    private final DelimiterFacade delimiterFacade;
+
+    public CalculatorFacadeImpl( DelimiterFacade delimiterFacade, OperandService operandService, CalculatorService calculatorService, OutputValueService outputValueService, OutputView outputView) {
+        this.operandService = operandService;
         this.calculatorService = calculatorService;
+        this.outputValueService = outputValueService;
+        this.outputView = outputView;
+        this.delimiterFacade = delimiterFacade;
     }
 
     @Override
     public void calculate(String value) {
         Validator.startValidate(value);
-        delimiterService.extractCustomDelimiter(value);
-        valueExtractService.extractValue(value);
-        calculatorService.addValue();
+        String regex = delimiterFacade.generateRegexFromValue(value);
+
+        List<Operand> operandList = operandService.extractOperand(value,regex);
+        operandService.saveOperandList(operandList);
+
+        Integer result = calculatorService.addOperandListValue(operandList);
+        OutputValue value1 = outputValueService.saveOutputValue(new OutputValue(result));
+
+        outputView.stringCalculatorResultView(value1);
+
 
     }
 }

--- a/src/main/java/com/java/service/calculator/CalculatorFacadeImpl.java
+++ b/src/main/java/com/java/service/calculator/CalculatorFacadeImpl.java
@@ -7,6 +7,7 @@ import com.java.service.calculator.calculate.CalculatorService;
 import com.java.service.calculator.delimiter.DelimiterFacade;
 import com.java.service.calculator.delimiter.DelimiterFacadeImpl;
 import com.java.service.calculator.delimiter.DelimiterService;
+import com.java.service.calculator.operand.OperandFacade;
 import com.java.service.calculator.validator.Validator;
 import com.java.service.calculator.operand.OperandService;
 import com.java.service.io.output.OutputValueService;
@@ -15,34 +16,25 @@ import com.java.view.OutputView;
 import java.util.List;
 
 public class CalculatorFacadeImpl implements CalculatorFacade {
-    private final OperandService operandService;
     private final CalculatorService calculatorService;
     private final OutputValueService outputValueService;
-    private final OutputView outputView;
 
     private final DelimiterFacade delimiterFacade;
+    private final OperandFacade operandFacade;
 
-    public CalculatorFacadeImpl( DelimiterFacade delimiterFacade, OperandService operandService, CalculatorService calculatorService, OutputValueService outputValueService, OutputView outputView) {
-        this.operandService = operandService;
+    public CalculatorFacadeImpl(DelimiterFacade delimiterFacade, CalculatorService calculatorService, OutputValueService outputValueService, OperandFacade operandFacade) {
         this.calculatorService = calculatorService;
         this.outputValueService = outputValueService;
-        this.outputView = outputView;
         this.delimiterFacade = delimiterFacade;
+        this.operandFacade = operandFacade;
     }
 
     @Override
-    public void calculate(String value) {
+    public OutputValue calculate(String value) {
         Validator.startValidate(value);
         String regex = delimiterFacade.generateRegexFromValue(value);
-
-        List<Operand> operandList = operandService.extractOperand(value,regex);
-        operandService.saveOperandList(operandList);
-
+        List<Operand> operandList = operandFacade.extractAndSaveOperand(regex, value);
         Integer result = calculatorService.addOperandListValue(operandList);
-        OutputValue value1 = outputValueService.saveOutputValue(new OutputValue(result));
-
-        outputView.stringCalculatorResultView(value1);
-
-
+        return outputValueService.saveOutputValue(new OutputValue(result));
     }
 }

--- a/src/main/java/com/java/service/calculator/calculate/CalculatorService.java
+++ b/src/main/java/com/java/service/calculator/calculate/CalculatorService.java
@@ -1,5 +1,10 @@
 package com.java.service.calculator.calculate;
 
+import com.java.repository.operand.Operand;
+
+import java.util.List;
+
 public interface CalculatorService {
-    public void addValue();
+    Integer addOperandListValue(List<Operand> operand);
+    Integer addIntegerListValue(List<Integer> operand);
 }

--- a/src/main/java/com/java/service/calculator/calculate/CalculatorServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/calculate/CalculatorServiceImpl.java
@@ -4,23 +4,24 @@ import com.java.repository.operand.Operand;
 import com.java.repository.operand.OperandRepository;
 import com.java.repository.output.OutputValue;
 import com.java.repository.output.OutputValueRepository;
+import com.java.service.calculator.operand.OperandService;
 
 import java.util.List;
 
 public class CalculatorServiceImpl implements CalculatorService{
-    private final OperandRepository operandRepository;
-    private final OutputValueRepository outputValueRepository;
-
-    public CalculatorServiceImpl(OperandRepository operandRepository, OutputValueRepository outputValueRepository) {
-        this.operandRepository = operandRepository;
-        this.outputValueRepository = outputValueRepository;
-    }
-
     @Override
-    public void addValue() {
-        List<Operand> operands = operandRepository.getOperand();
-        List<Integer> sexy = operands.stream().map(Operand::getValue).toList();
-        int sum = sexy.stream().reduce(0, Integer::sum);
-        outputValueRepository.addOutputValue(new OutputValue(sum));
+    public Integer addIntegerListValue(List<Integer> operand) { //여기는 딱 더하기만 해주자.
+        return operand.stream().reduce(0, Integer::sum);
     }
+    @Override
+    public Integer addOperandListValue(List<Operand> operand) { //여기는 딱 더하기만 해주자.
+        List<Integer> integerOperand =  convertOperendListToInteger(operand);
+        return integerOperand.stream().reduce(0, Integer::sum);
+    }
+
+    public List<Integer> convertOperendListToInteger(List<Operand> operandList){
+        List<Integer> integerList = operandList.stream().map(Operand::getValue).toList();
+        return integerList;
+    }
+    
 }

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterFacade.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterFacade.java
@@ -1,0 +1,5 @@
+package com.java.service.calculator.delimiter;
+
+public interface DelimiterFacade {
+    public String generateRegexFromValue(String Value);
+}

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterFacadeImpl.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterFacadeImpl.java
@@ -1,0 +1,21 @@
+package com.java.service.calculator.delimiter;
+
+import com.java.repository.delimiter.Delimiter;
+
+import java.util.List;
+
+public class DelimiterFacadeImpl implements DelimiterFacade{
+    private final DelimiterService delimiterService;
+
+    public DelimiterFacadeImpl(DelimiterService delimiterService) {
+        this.delimiterService = delimiterService;
+    }
+
+    @Override
+    public String generateRegexFromValue(String value) {
+        delimiterService.extractCustomDelimiter(value);
+        List<Delimiter> delimiterList = delimiterService.getDelimiterList();
+        String regex = delimiterService.generateDelimiterRegex(delimiterList);
+        return regex;
+    }
+}

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterService.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterService.java
@@ -2,7 +2,11 @@ package com.java.service.calculator.delimiter;
 
 import com.java.repository.delimiter.Delimiter;
 
+import java.util.List;
+
 public interface DelimiterService {
     public void extractCustomDelimiter(String inputValue);
     public void saveCustomDelimiter(Delimiter delimiter);
+    public String generateDelimiterRegex(List<Delimiter> delimiters);
+    public List<Delimiter> getDelimiterList();
 }

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterService.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterService.java
@@ -5,8 +5,9 @@ import com.java.repository.delimiter.Delimiter;
 import java.util.List;
 
 public interface DelimiterService {
-    public void extractCustomDelimiter(String inputValue);
-    public void saveCustomDelimiter(Delimiter delimiter);
+    public List<Delimiter> extractCustomDelimiter(String inputValue);
     public String generateDelimiterRegex(List<Delimiter> delimiters);
+    public void saveCustomDelimiter(Delimiter delimiter);
+    public void saveAllCustomDelimter(List<Delimiter> delimiters);
     public List<Delimiter> getDelimiterList();
 }

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterServiceImpl2.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterServiceImpl2.java
@@ -4,6 +4,7 @@ import com.java.exception.ErrorCode;
 import com.java.repository.delimiter.Delimiter;
 import com.java.repository.delimiter.DelimiterRepository;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -36,5 +37,20 @@ public class DelimiterServiceImpl2 implements DelimiterService {
     public void saveCustomDelimiter(Delimiter delimiter) {
         delimiterRepository.addDelimiter(delimiter);
     }
+
+    @Override
+    public String generateDelimiterRegex(List<Delimiter> delimiters) {
+        String regex = String.join("|", delimiters.stream()
+                .map(Delimiter::getValue)
+                .map(Pattern::quote)
+                .toArray(String[]::new));
+        return regex;
+    }
+
+    @Override
+    public List<Delimiter> getDelimiterList() {
+        return delimiterRepository.getDelimiterRepo();
+    }
+
 
 }

--- a/src/main/java/com/java/service/calculator/delimiter/DelimiterServiceImpl2.java
+++ b/src/main/java/com/java/service/calculator/delimiter/DelimiterServiceImpl2.java
@@ -4,6 +4,8 @@ import com.java.exception.ErrorCode;
 import com.java.repository.delimiter.Delimiter;
 import com.java.repository.delimiter.DelimiterRepository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -18,24 +20,21 @@ public class DelimiterServiceImpl2 implements DelimiterService {
 
 
     @Override
-    public void extractCustomDelimiter(String inputValue) {
+    public List<Delimiter> extractCustomDelimiter(String inputValue) {
+        List<Delimiter> extractedDelimiter = new ArrayList<>();
         Pattern pattern = Pattern.compile(REGEX);
         Matcher matcher = pattern.matcher(inputValue);
         if (matcher.find()) {
             String customDelimiter = matcher.group(1);
+            String customDelimiter2 = matcher.group(0);
             if (customDelimiter.length() != 1) {
                 throw new IllegalArgumentException(ErrorCode.CUSTOM_DELIMITER_IS_NOT_VALIDATED.getErrorMessage());
             }
-            saveCustomDelimiter(new Delimiter(customDelimiter));
-            saveCustomDelimiter(new Delimiter(matcher.group(0)));
-            String remaining = inputValue.substring(matcher.end()).trim();
-            extractCustomDelimiter(remaining);
+            extractedDelimiter.addAll(Arrays.asList(new Delimiter(customDelimiter),new Delimiter(customDelimiter2)));
+            extractCustomDelimiter(inputValue.substring(matcher.end()).trim());
         }
-    }
-
-    @Override
-    public void saveCustomDelimiter(Delimiter delimiter) {
-        delimiterRepository.addDelimiter(delimiter);
+        saveAllCustomDelimter(extractedDelimiter);
+        return extractedDelimiter;
     }
 
     @Override
@@ -45,6 +44,16 @@ public class DelimiterServiceImpl2 implements DelimiterService {
                 .map(Pattern::quote)
                 .toArray(String[]::new));
         return regex;
+    }
+
+    @Override
+    public void saveCustomDelimiter(Delimiter delimiter) {
+        delimiterRepository.addDelimiter(delimiter);
+    }
+
+    @Override
+    public void saveAllCustomDelimter(List<Delimiter> delimiters) {
+        delimiterRepository.addAllDelimiter(delimiters);
     }
 
     @Override

--- a/src/main/java/com/java/service/calculator/operand/OperandFacade.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandFacade.java
@@ -1,0 +1,9 @@
+package com.java.service.calculator.operand;
+
+import com.java.repository.operand.Operand;
+
+import java.util.List;
+
+public interface OperandFacade {
+    public List<Operand> extractAndSaveOperand(String regex, String value);
+}

--- a/src/main/java/com/java/service/calculator/operand/OperandFacadeImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandFacadeImpl.java
@@ -1,0 +1,20 @@
+package com.java.service.calculator.operand;
+
+import com.java.repository.operand.Operand;
+
+import java.util.List;
+
+public class OperandFacadeImpl implements OperandFacade{
+    private final OperandService operandService;
+
+    public OperandFacadeImpl(OperandService operandService) {
+        this.operandService = operandService;
+    }
+
+    @Override
+    public List<Operand> extractAndSaveOperand(String regex, String value) {
+        List<Operand> operandList = operandService.extractOperand(value,regex);
+        operandService.saveOperandList(operandList);
+        return operandList;
+    }
+}

--- a/src/main/java/com/java/service/calculator/operand/OperandService.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandService.java
@@ -1,0 +1,5 @@
+package com.java.service.calculator.operand;
+
+public interface OperandService {
+    public void extractValue(String inputValue,String regex);
+}

--- a/src/main/java/com/java/service/calculator/operand/OperandService.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandService.java
@@ -6,4 +6,7 @@ import java.util.List;
 
 public interface OperandService {
     public List<Operand> extractOperand(String inputValue, String regex);
+    public void saveOperand();
+    public void saveOperandList(List<Operand> operandList);
+    public List<Operand> getOperandList();
 }

--- a/src/main/java/com/java/service/calculator/operand/OperandService.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandService.java
@@ -1,5 +1,9 @@
 package com.java.service.calculator.operand;
 
+import com.java.repository.operand.Operand;
+
+import java.util.List;
+
 public interface OperandService {
-    public void extractValue(String inputValue,String regex);
+    public List<Operand> extractOperand(String inputValue, String regex);
 }

--- a/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
@@ -4,6 +4,10 @@ import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.operand.Operand;
 import com.java.repository.operand.OperandRepository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 public class OperandServiceImpl implements OperandService {
     private final DelimiterRepository delimiterRepository;
     private final OperandRepository operandRepository;
@@ -14,10 +18,25 @@ public class OperandServiceImpl implements OperandService {
     }
 
     @Override
-    public void extractValue(String inputValue, String regex) {
+    public List<Operand> extractOperand(String inputValue, String regex) {
         String[] splitResult = inputValue.split(regex);
-        for(String operand : splitResult){
-            operandRepository.addOperand(new Operand(Integer.parseInt(operand)));
+        List<String> result = Arrays.asList(splitResult);
+        return convertStringListToOperand(result);
+    }
+
+    public void saveOperand(){}
+    public void saveOperandList(List<Operand> operandList){
+        for(Operand operand : operandList){
+            operandRepository.addOperand(operand);
         }
+    }
+
+
+    public List<Operand> convertStringListToOperand(List<String> strOperand){
+        List<Operand> operandList = new ArrayList<>();
+        for(String operand : strOperand){
+            operandList.add(new Operand(Integer.parseInt(operand)));
+        }
+        return operandList;
     }
 }

--- a/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
@@ -4,11 +4,11 @@ import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.operand.Operand;
 import com.java.repository.operand.OperandRepository;
 
-public class ValueExtractServiceImpl implements ValueExtractService{
+public class OperandServiceImpl implements OperandService {
     private final DelimiterRepository delimiterRepository;
     private final OperandRepository operandRepository;
 
-    public ValueExtractServiceImpl(DelimiterRepository delimiterRepository, OperandRepository operandRepository) {
+    public OperandServiceImpl(DelimiterRepository delimiterRepository, OperandRepository operandRepository) {
         this.delimiterRepository = delimiterRepository;
         this.operandRepository = operandRepository;
     }

--- a/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
@@ -21,12 +21,17 @@ public class OperandServiceImpl implements OperandService {
         List<String> result = Arrays.asList(splitResult);
         return convertStringListToOperand(result);
     }
-
+    @Override
     public void saveOperand(){}
+    @Override
     public void saveOperandList(List<Operand> operandList){
         for(Operand operand : operandList){
             operandRepository.addOperand(operand);
         }
+    }
+    @Override
+    public List<Operand> getOperandList(){
+        return operandRepository.getOperand();
     }
 
 

--- a/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
@@ -9,11 +9,9 @@ import java.util.Arrays;
 import java.util.List;
 
 public class OperandServiceImpl implements OperandService {
-    private final DelimiterRepository delimiterRepository;
     private final OperandRepository operandRepository;
 
-    public OperandServiceImpl(DelimiterRepository delimiterRepository, OperandRepository operandRepository) {
-        this.delimiterRepository = delimiterRepository;
+    public OperandServiceImpl(OperandRepository operandRepository) {
         this.operandRepository = operandRepository;
     }
 

--- a/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/OperandServiceImpl.java
@@ -3,6 +3,8 @@ package com.java.service.calculator.operand;
 import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.operand.Operand;
 import com.java.repository.operand.OperandRepository;
+import com.java.service.calculator.operand.util.OperandUtil;
+import com.java.service.calculator.validator.Validator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,7 +40,8 @@ public class OperandServiceImpl implements OperandService {
     public List<Operand> convertStringListToOperand(List<String> strOperand){
         List<Operand> operandList = new ArrayList<>();
         for(String operand : strOperand){
-            operandList.add(new Operand(Integer.parseInt(operand)));
+            Validator.isOnlyInteger(operand);
+            operandList.add(OperandUtil.convertStringToIntegerAndOperand(operand));
         }
         return operandList;
     }

--- a/src/main/java/com/java/service/calculator/operand/ValueExtractServiceImpl.java
+++ b/src/main/java/com/java/service/calculator/operand/ValueExtractServiceImpl.java
@@ -1,12 +1,8 @@
-package com.java.service.calculator.valueextractor;
+package com.java.service.calculator.operand;
 
-import com.java.repository.delimiter.Delimiter;
 import com.java.repository.delimiter.DelimiterRepository;
 import com.java.repository.operand.Operand;
 import com.java.repository.operand.OperandRepository;
-
-import java.util.List;
-import java.util.regex.Pattern;
 
 public class ValueExtractServiceImpl implements ValueExtractService{
     private final DelimiterRepository delimiterRepository;
@@ -18,12 +14,7 @@ public class ValueExtractServiceImpl implements ValueExtractService{
     }
 
     @Override
-    public void extractValue(String inputValue) {
-        List<Delimiter> dex = delimiterRepository.getDelimiterRepo();
-        String regex = String.join("|", dex.stream()
-                .map(Delimiter::getValue)
-                .map(Pattern::quote)
-                .toArray(String[]::new));
+    public void extractValue(String inputValue, String regex) {
         String[] splitResult = inputValue.split(regex);
         for(String operand : splitResult){
             operandRepository.addOperand(new Operand(Integer.parseInt(operand)));

--- a/src/main/java/com/java/service/calculator/operand/util/OperandUtil.java
+++ b/src/main/java/com/java/service/calculator/operand/util/OperandUtil.java
@@ -1,0 +1,24 @@
+package com.java.service.calculator.operand.util;
+
+import com.java.exception.ErrorCode;
+import com.java.repository.operand.Operand;
+
+public class OperandUtil {
+
+    public static Operand convertStringToIntegerAndOperand(String operand){
+        try {
+            Integer integerOperand = Integer.parseInt(operand);
+            return new Operand(integerOperand);
+        }catch(IllegalArgumentException e){
+            throw new IllegalArgumentException(ErrorCode.INPUT_VALUE_ONLY_INTEGER.getErrorMessage() + e);
+        }
+    }
+//public static Operand convertStringToIntegerAndOperand(String operand){
+//    try {
+//        Integer integerOperand = Integer.parseInt(operand);
+//        return new Operand(integerOperand);
+//    }catch(IllegalArgumentException e){
+//        throw new IllegalArgumentException(ErrorCode.INPUT_VALUE_ONLY_INTEGER.getErrorMessage() + e);
+//    }
+//}
+}

--- a/src/main/java/com/java/service/calculator/validator/Validator.java
+++ b/src/main/java/com/java/service/calculator/validator/Validator.java
@@ -2,7 +2,13 @@ package com.java.service.calculator.validator;
 
 import com.java.exception.ErrorCode;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class Validator {
+
+    private static final String REGEX ="^-?\\d+$";
+
     public static void startValidate(String inputValue){
         isOnlySpace(inputValue);
         isEmpty(inputValue);
@@ -16,6 +22,12 @@ public class Validator {
     public static void isEmpty(String inputValue){
         if(inputValue.isEmpty()){
             throw new IllegalArgumentException(ErrorCode.NO_ARG_INPUT.getErrorMessage());
+        }
+    }
+
+    public static void isOnlyInteger(String inputValue){
+        if(!inputValue.matches(REGEX)){
+            throw new IllegalArgumentException(ErrorCode.INPUT_VALUE_ONLY_INTEGER.getErrorMessage());
         }
     }
 

--- a/src/main/java/com/java/service/calculator/valueextractor/ValueExtractService.java
+++ b/src/main/java/com/java/service/calculator/valueextractor/ValueExtractService.java
@@ -1,5 +1,0 @@
-package com.java.service.calculator.valueextractor;
-
-public interface ValueExtractService {
-    public void extractValue(String inputValue);
-}

--- a/src/main/java/com/java/service/io/InputValueService.java
+++ b/src/main/java/com/java/service/io/InputValueService.java
@@ -4,4 +4,5 @@ import java.io.IOException;
 
 public interface InputValueService {
     public String readInput() throws IOException;
+    public void saveInput(String inputValue);
 }

--- a/src/main/java/com/java/service/io/InputValueService.java
+++ b/src/main/java/com/java/service/io/InputValueService.java
@@ -2,6 +2,6 @@ package com.java.service.io;
 
 import java.io.IOException;
 
-public interface InputValueHandler {
+public interface InputValueService {
     public String readInput() throws IOException;
 }

--- a/src/main/java/com/java/service/io/InputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/InputValueServiceImpl.java
@@ -7,10 +7,10 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-public class InputValueHandlerImpl implements InputValueHandler{
+public class InputValueServiceImpl implements InputValueService {
     private final InputValueRepository inputValueRepository;
 
-    public InputValueHandlerImpl(InputValueRepository inputValueRepository1) {
+    public InputValueServiceImpl(InputValueRepository inputValueRepository1) {
         this.inputValueRepository = inputValueRepository1;
     }
 

--- a/src/main/java/com/java/service/io/InputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/InputValueServiceImpl.java
@@ -13,12 +13,16 @@ public class InputValueServiceImpl implements InputValueService {
     public InputValueServiceImpl(InputValueRepository inputValueRepository1) {
         this.inputValueRepository = inputValueRepository1;
     }
-
+    @Override
     public String readInput() throws IOException{
             BufferedReader input = new BufferedReader(new InputStreamReader(System.in));
             String inputValue;
             inputValue = (String)input.readLine();
-            inputValueRepository.addInputValue(new InputValue(inputValue));
             return inputValue;
+    }
+
+    @Override
+    public void saveInput(String inputValue) {
+        inputValueRepository.addInputValue(new InputValue(inputValue));
     }
 }

--- a/src/main/java/com/java/service/io/OutputValueService.java
+++ b/src/main/java/com/java/service/io/OutputValueService.java
@@ -4,6 +4,6 @@ import com.java.repository.output.OutputValue;
 
 import java.util.List;
 
-public interface OutputValueHandler {
+public interface OutputValueService {
     public List<OutputValue> readOutput();
 }

--- a/src/main/java/com/java/service/io/OutputValueService.java
+++ b/src/main/java/com/java/service/io/OutputValueService.java
@@ -5,7 +5,7 @@ import com.java.repository.output.OutputValue;
 import java.util.List;
 
 public interface OutputValueService {
-    public List<OutputValue> getOutput();
-    public Integer convertOutputToInteger(OutputValue value);
-    public String convertOutputToString(OutputValue value);
+    public List<OutputValue> getOutputList();
+    public Integer getOutputValueToInteger(OutputValue outputValue);
+    public String getOutputValueToString(OutputValue outputValue);
 }

--- a/src/main/java/com/java/service/io/OutputValueService.java
+++ b/src/main/java/com/java/service/io/OutputValueService.java
@@ -5,5 +5,7 @@ import com.java.repository.output.OutputValue;
 import java.util.List;
 
 public interface OutputValueService {
-    public List<OutputValue> readOutput();
+    public List<OutputValue> getOutput();
+    public Integer convertOutputToInteger(OutputValue value);
+    public String convertOutputToString(OutputValue value);
 }

--- a/src/main/java/com/java/service/io/OutputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/OutputValueServiceImpl.java
@@ -5,10 +5,10 @@ import com.java.repository.output.OutputValueRepository;
 
 import java.util.List;
 
-public class OutputValueHandlerImpl implements OutputValueHandler{
+public class OutputValueServiceImpl implements OutputValueService {
     private final OutputValueRepository outputValueRepository;
 
-    public OutputValueHandlerImpl(OutputValueRepository outputValueRepository) {
+    public OutputValueServiceImpl(OutputValueRepository outputValueRepository) {
         this.outputValueRepository = outputValueRepository;
     }
 
@@ -16,4 +16,5 @@ public class OutputValueHandlerImpl implements OutputValueHandler{
     public List<OutputValue> readOutput() {
         return outputValueRepository.getOutputValue();
     }
+
 }

--- a/src/main/java/com/java/service/io/OutputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/OutputValueServiceImpl.java
@@ -2,6 +2,7 @@ package com.java.service.io;
 
 import com.java.repository.output.OutputValue;
 import com.java.repository.output.OutputValueRepository;
+import com.java.service.io.util.OutputValueUtil;
 
 import java.util.List;
 
@@ -13,16 +14,17 @@ public class OutputValueServiceImpl implements OutputValueService {
     }
 
     @Override
-    public List<OutputValue> getOutput() {
+    public List<OutputValue> getOutputList() {
         return outputValueRepository.getOutputValue();
     }
+
     @Override
-    public Integer convertOutputToInteger(OutputValue value){
-        return value.getValue();
+    public Integer getOutputValueToInteger(OutputValue outputValue){
+        return OutputValueUtil.convertOutputToInteger(outputValue);
     }
     @Override
-    public String convertOutputToString(OutputValue value){
-        return String.valueOf(convertOutputToInteger(value));
+    public String getOutputValueToString(OutputValue outputValue){
+        return OutputValueUtil.convertOutputToString(outputValue);
     }
 
 

--- a/src/main/java/com/java/service/io/OutputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/OutputValueServiceImpl.java
@@ -13,8 +13,18 @@ public class OutputValueServiceImpl implements OutputValueService {
     }
 
     @Override
-    public List<OutputValue> readOutput() {
+    public List<OutputValue> getOutput() {
         return outputValueRepository.getOutputValue();
     }
+    @Override
+    public Integer convertOutputToInteger(OutputValue value){
+        return value.getValue();
+    }
+    @Override
+    public String convertOutputToString(OutputValue value){
+        return String.valueOf(convertOutputToInteger(value));
+    }
+
+
 
 }

--- a/src/main/java/com/java/service/io/input/InputValueService.java
+++ b/src/main/java/com/java/service/io/input/InputValueService.java
@@ -1,4 +1,5 @@
-package com.java.service.io;
+package com.java.service.io.input;
+
 
 import java.io.IOException;
 

--- a/src/main/java/com/java/service/io/input/InputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/input/InputValueServiceImpl.java
@@ -1,4 +1,4 @@
-package com.java.service.io;
+package com.java.service.io.input;
 
 import com.java.repository.input.InputValue;
 import com.java.repository.input.InputValueRepository;

--- a/src/main/java/com/java/service/io/output/OutputValueService.java
+++ b/src/main/java/com/java/service/io/output/OutputValueService.java
@@ -1,4 +1,4 @@
-package com.java.service.io;
+package com.java.service.io.output;
 
 import com.java.repository.output.OutputValue;
 
@@ -8,4 +8,5 @@ public interface OutputValueService {
     public List<OutputValue> getOutputList();
     public Integer getOutputValueToInteger(OutputValue outputValue);
     public String getOutputValueToString(OutputValue outputValue);
+    public OutputValue saveOutputValue(OutputValue outputValue);
 }

--- a/src/main/java/com/java/service/io/output/OutputValueServiceImpl.java
+++ b/src/main/java/com/java/service/io/output/OutputValueServiceImpl.java
@@ -1,8 +1,8 @@
-package com.java.service.io;
+package com.java.service.io.output;
 
 import com.java.repository.output.OutputValue;
 import com.java.repository.output.OutputValueRepository;
-import com.java.service.io.util.OutputValueUtil;
+import com.java.service.io.output.util.OutputValueUtil;
 
 import java.util.List;
 
@@ -27,6 +27,11 @@ public class OutputValueServiceImpl implements OutputValueService {
         return OutputValueUtil.convertOutputToString(outputValue);
     }
 
+    @Override
+    public OutputValue saveOutputValue(OutputValue outputValue) {
+        outputValueRepository.addOutputValue(outputValue);
+        return outputValue;
+    }
 
 
 }

--- a/src/main/java/com/java/service/io/output/util/OutputValueUtil.java
+++ b/src/main/java/com/java/service/io/output/util/OutputValueUtil.java
@@ -1,4 +1,4 @@
-package com.java.service.io.util;
+package com.java.service.io.output.util;
 
 import com.java.repository.output.OutputValue;
 

--- a/src/main/java/com/java/service/io/util/OutputValueUtil.java
+++ b/src/main/java/com/java/service/io/util/OutputValueUtil.java
@@ -1,0 +1,16 @@
+package com.java.service.io.util;
+
+import com.java.repository.output.OutputValue;
+
+public class OutputValueUtil {
+
+    public static Integer convertOutputToInteger(OutputValue value){
+        return value.getValue();
+    }
+
+    public static String convertOutputToString(OutputValue value){
+        return String.valueOf(convertOutputToInteger(value));
+    }
+    // 단순한 형변환이지만, OutputValue의 대한 형 변환이므로, 이 메서드를 outputValueService외에 다른 서비스에서 직접적으로 사용한다면 책임 분리가
+    //명확하지 않은거 같아서 OutputValue에서 호출하겠다.
+}

--- a/src/main/java/com/java/view/InputView.java
+++ b/src/main/java/com/java/view/InputView.java
@@ -1,18 +1,18 @@
 package com.java.view;
 
-import com.java.service.io.InputValueHandler;
+import com.java.service.io.input.InputValueService;
 
 import java.io.IOException;
 
 public class InputView {
-    private final InputValueHandler inputValueHandler;
+    private final InputValueService inputValueService;
 
-    public InputView(InputValueHandler inputValueHandler) {
-        this.inputValueHandler = inputValueHandler;
+    public InputView(InputValueService inputValueService) {
+        this.inputValueService = inputValueService;
     }
 
     public String stringCalculatorView() throws IOException {
         System.out.println(InputMessage.ENTER_VALUE.getMessage());
-        return inputValueHandler.readInput();
+        return inputValueService.readInput();
     }
 }

--- a/src/main/java/com/java/view/OutputView.java
+++ b/src/main/java/com/java/view/OutputView.java
@@ -2,20 +2,20 @@ package com.java.view;
 
 import com.java.repository.output.OutputValue;
 import com.java.repository.output.OutputValueRepository;
+import com.java.service.io.output.OutputValueService;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 public class OutputView {
-    private final OutputValueRepository outputValueRepository;
+    private final OutputValueService outputValueService;
 
-    public OutputView(OutputValueRepository outputValueRepository) {
-        this.outputValueRepository = outputValueRepository;
+    public OutputView(OutputValueService outputValueService) {
+        this.outputValueService = outputValueService;
     }
 
-    public void stringCalculatorResultView(){
-        List<OutputValue> OutputValues= outputValueRepository.getOutputValue();
-        String result = OutputValues.stream().map(OutputValue::getValue).map(String::valueOf).collect(Collectors.joining());
+    public void stringCalculatorResultView(OutputValue outputValue){
+        String result = outputValueService.getOutputValueToString(outputValue); //어떤 인수가 와야하는지 보면 좋을거같아서 이부부은 분리안함.
         System.out.println(OutputMessage.SHOW_RESULT_VALUE.getMessage()+result);
     }
 }

--- a/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
+++ b/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
@@ -1,0 +1,46 @@
+package service.calculator.delimiter;
+
+import com.java.repository.delimiter.Delimiter;
+import com.java.repository.delimiter.DelimiterRepository;
+import com.java.service.calculator.delimiter.DelimiterService;
+import com.java.service.calculator.delimiter.DelimiterServiceImpl2;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DelimiterServiceImpl2Test {
+    private DelimiterRepository delimiterRepository;
+    private DelimiterService delimiterService;
+
+    @BeforeEach
+    public void beforeEach(){
+        // DelimiterRepository와 DelimiterService 객체를 초기화
+        delimiterRepository = new DelimiterRepository();  // DelimiterRepository 객체 생성
+        delimiterService = new DelimiterServiceImpl2(delimiterRepository);  // DelimiterService 생성
+    }
+    @Test
+    public void extractCustomDelimiterTest(){
+        //given
+        String inputValue = "1,2//!\\n3//@\\n4//#\\n";
+
+        //when
+        List<Delimiter> result = delimiterService.extractCustomDelimiter(inputValue);
+
+        // then
+        List<String> expectedDelimiters = List.of("!", "//!\\n", "@","//@\\n","#","//#\\n");
+
+        List<String> actualDelimiters = result.stream()
+                .map(Delimiter::getValue)
+                .collect(Collectors.toList());
+
+
+        assertIterableEquals(expectedDelimiters, actualDelimiters, "구분자 목록이 예상과 일치하지 않습니다.");
+    }
+
+
+}

--- a/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
+++ b/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
@@ -50,5 +50,27 @@ public class DelimiterServiceImpl2Test {
         });
     }
 
+    @Test
+    public void generateDelimiterRegexTest(){
+        //given
+        List<Delimiter> delimiters = List.of(
+                new Delimiter("!"),
+                new Delimiter("//!\\n"),
+                new Delimiter("@"),
+                new Delimiter("//@\\n"),
+                new Delimiter("#"),
+                new Delimiter("//#\\n")
+        );
+        //when
+        String regex = delimiterService.generateDelimiterRegex(delimiters);
+        //then
+        String expectedRegex = Pattern.quote("!") + "|" +
+                Pattern.quote("//!\\n") + "|" +
+                Pattern.quote("@") + "|" +
+                Pattern.quote("//@\\n") + "|" +
+                Pattern.quote("#") + "|" +
+                Pattern.quote("//#\\n");
+        assertEquals(expectedRegex, regex, "정규식이 예상과 일치하지 않습니다.");
 
+    }
 }

--- a/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
+++ b/src/test/java/service/calculator/delimiter/DelimiterServiceImpl2Test.java
@@ -42,5 +42,13 @@ public class DelimiterServiceImpl2Test {
         assertIterableEquals(expectedDelimiters, actualDelimiters, "구분자 목록이 예상과 일치하지 않습니다.");
     }
 
+    @Test
+    public void extractCustomDelimiterTest_WithIllegalArg_whenDelimiterIsNotSingleCharacter(){
+        String inputValue = "1,2//!@\\n3//@\\n4//#\\n";
+        assertThrows(IllegalArgumentException.class, () -> {
+            delimiterService.extractCustomDelimiter(inputValue);
+        });
+    }
+
 
 }


### PR DESCRIPTION
## 서비스 책임 분리 및 의존성 개선

전반적으로 하나의 메서드에서 여러가지 책임을 지고있는 부분 수정.

###문제점.

1. 단순히 값을 저장하고 가지고오는 기능밖에 없는 도메인들은 서비스로직은 안만들고 다른 서비스에서 직접 사용했었음.
이로 인해 하나의 서비스에 의존성이 많이 있었으나 도메인별로 서비스를 전부 만들어 필요한 경우 레포지토리가 아닌 서비스를 의존성 주입받게 설계하였음.

2. 대부분의 메서드가 인자값을 직접 받아서 쓰는게 아닌 데이터 베이스에서 본인이 직접 조회, 혹은 저장하는 로직이였으나
(여러 책임의 가중, 해당 로직이 특정 레포지토리에 의존을 받는 문제, 확장성을 고려하지 않았었음)
저장의 책임만 지게하는 메서드를 따로 만들어주고, 메서드는 인자를 받아서 값을 리턴해주는 방식으로 변경.


## 예시

### 기존: 하나의 서비스에 다른 도메인의 레포지토리까지 의존성을 받아서 사용

기존에는 하나의 서비스에서 다른 도메인의 레포지토리를 직접 의존하여 값을 처리하는 방식이었습니다. 예를 들어, 구분자와 피연산자를 처리하는 서비스에서 `DelimiterRepository`를 직접 사용하여 구분자를 가져오고, 이를 이용해 정규식으로 값을 분리하는 로직이 포함되었습니다.

#### 기존 코드 예시

```java
package com.java.service.calculator.operand;

@Override
public void extractValue(String inputValue) {
    List<Delimiter> dex = delimiterRepository.getDelimiterRepo();
    String regex = String.join("|", dex.stream()
            .map(Delimiter::getValue)
            .map(Pattern::quote)
            .toArray(String[]::new));
    String[] splitResult = inputValue.split(regex);
    for (String operand : splitResult) {
        operandRepository.addOperand(new Operand(Integer.parseInt(operand)));
    }
}

##문제점
기존에 값을 추출하기 위해 정규표현식을 레포지토리에서 가지고 와서 추출 로직을 사용, 메서드 이름부터 의도를 파악하기 힘들다고 판단, 구분자를 인자로 받아서 쓰지 않고, 다른 도메인의 레포지토리를 직접 의존 받아서 사용.

```
    @Override
    public List<Operand> extractOperand(String inputValue, String regex) {
        String[] splitResult = inputValue.split(regex);
        List<String> result = Arrays.asList(splitResult);
        return convertStringListToOperand(result);
    }
```
피연산자를 추출 한다는 의도를 명확하게 하는 메서드 이름사용.
문자를 쪼개고, 구분자를 레포지토리에서 가지고 오고 형변환을 하는 여러가지 책임이 있었으나,
값을 추출하기만 하는 역할을 하고 저장은 다른 메서드에서 하도록 반환값만 던저 주는 형식으로 변경.

